### PR TITLE
XML: Revert Oga -> Nokogiri

### DIFF
--- a/docs/api/find.md
+++ b/docs/api/find.md
@@ -11,7 +11,7 @@
 
 | Type | Description |
 | --- | --- |
-| instance | A [Oga](https://github.com/YorickPeterse/oga) element instance. |
+| instance | A [Nokogiri](https://github.com/sparklemotion/nokogiri) element instance. |
 
 
 ## Usage
@@ -45,7 +45,7 @@ el["class"]   # quote
 
 ### Chaining
 
-Joule has enhanced Oga's `XML::Element` class by allowing you to find elements within elements.
+Joule has enhanced Nokogiri's `XML::Element` class by allowing you to find elements within elements.
 
 In the example below, we're able to find the inner `.pika` selector within the outer `.pikachu` selector.
 ```rb

--- a/docs/api/find_all.md
+++ b/docs/api/find_all.md
@@ -11,7 +11,7 @@
 
 | Type | Description |
 | --- | --- |
-| array | An array of [Oga](https://github.com/YorickPeterse/oga) element instances. |
+| array | An array of [Nokogiri](https://github.com/sparklemotion/nokogiri) element instances. |
 
 
 ## Usage

--- a/docs/api/prop.md
+++ b/docs/api/prop.md
@@ -8,7 +8,7 @@
 
 #### Aliases
 
-**[.get()](http://code.yorickpeterse.com/oga/latest/Oga/XML/Element.html#get-instance_method)**
+**[.attr()](http://www.rubydoc.info/github/sparklemotion/nokogiri/Nokogiri/XML/Attr)**
 
 
 #### Returns

--- a/jekyll-joule.gemspec
+++ b/jekyll-joule.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "jekyll", ">= 3.1.2"
-  spec.add_runtime_dependency "oga", "~> 2.10"
+  spec.add_runtime_dependency "nokogiri", "~> 1.8"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/jekyll/extensions/xml_element.rb
+++ b/lib/jekyll/extensions/xml_element.rb
@@ -1,4 +1,4 @@
-module Oga
+module Nokogiri
   module XML
     class Element
       def find_all *args
@@ -10,7 +10,7 @@ module Oga
       end
 
       def prop *args
-        self.get *args
+        self.attr *args
       end
     end
   end

--- a/lib/jekyll/joule.rb
+++ b/lib/jekyll/joule.rb
@@ -1,3 +1,3 @@
 require "jekyll/joule/version"
 require "jekyll/joule/site"
-require "jekyll/extensions/oga_element"
+require "jekyll/extensions/xml_element"

--- a/lib/jekyll/joule/site.rb
+++ b/lib/jekyll/joule/site.rb
@@ -1,6 +1,6 @@
 require "jekyll"
 require "jekyll/joule/page"
-require "oga"
+require "nokogiri"
 
 module Jekyll
   module Joule
@@ -37,7 +37,7 @@ module Jekyll
         page = Jekyll::Joule::Page.new(@site, @site.source, "/", @test_page_name)
         page.reparse(content)
         @data = generate(page)
-        @html = Oga.parse_html(@data.content)
+        @html = Nokogiri::HTML(@data.content)
 
         return self
       end

--- a/test/test_joule_nokogiri_ext.rb
+++ b/test/test_joule_nokogiri_ext.rb
@@ -1,7 +1,7 @@
 require "helper"
 
-class JouleOgaExtTest < JekyllUnitTest
-  should "extend Oga's Element class with find method" do
+class JouleNokogiriExtTest < JekyllUnitTest
+  should "extend Nokogiri's Element class with find method" do
     html = %Q[
       <div class="hello">
         <h1>Yes</h1>
@@ -19,7 +19,7 @@ class JouleOgaExtTest < JekyllUnitTest
     assert(h2.text.include?("No"))
   end
 
-  should "extend Oga's Element class with find_all method" do
+  should "extend Nokogiri's Element class with find_all method" do
     html = %Q[
       <div class="hello">
         <h2>Yes</h2>
@@ -37,7 +37,7 @@ class JouleOgaExtTest < JekyllUnitTest
     assert(h2.first.text.include?("Yes"))
   end
 
-  should "extend Oga's Element class with prop method" do
+  should "extend Nokogiri's Element class with prop method" do
     html = %Q[
       <div class="hello" style="display: block;">
         <h2>Yes</h2>


### PR DESCRIPTION
There are 2 main reasons for this:

1. Nokogiri actually renders XML into the complete HTML string, which makes it INCREDIBLY useful for debugging tests (a common use-case when creating components with jekyll-spark).
2. We experienced a gem dependency issue with Oga re: ruby-ll (2.1.2) (spotted by @seanehalpin )

Joule was originally created with Nokogiri. However, we switched to Oga since Oga is a MUCH lighter gem package, which speeds up `bundle install` times. However, this convenience may not be worth the stability + actual HTML render (as described above)

Note: This should be minor version bumped.